### PR TITLE
Delete single contact method added + get account response fix for reseller

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add this dependency to your project's POM:
 <dependency>
     <groupId>com.sendinblue</groupId>
     <artifactId>sib-api-v3-sdk</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <scope>compile</scope>
 </dependency>
 ```
@@ -32,7 +32,7 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "com.sendinblue:sib-api-v3-sdk:2.0.0"
+compile "com.sendinblue:sib-api-v3-sdk:2.0.1"
 ```
 
 ### Others
@@ -45,7 +45,7 @@ At first generate the JAR by executing:
 
 Then manually install the following JARs:
 
-* target/sib-api-v3-sdk-2.0.0.jar
+* target/sib-api-v3-sdk-2.0.1.jar
 * target/lib/*.jar
 
 ## Getting Started
@@ -103,6 +103,7 @@ Class | Method | HTTP request | Description
 *ContactsApi* | [**createFolder**](docs/ContactsApi.md#createFolder) | **POST** /contacts/folders | Create a folder
 *ContactsApi* | [**createList**](docs/ContactsApi.md#createList) | **POST** /contacts/lists | Create a list
 *ContactsApi* | [**deleteAttribute**](docs/ContactsApi.md#deleteAttribute) | **DELETE** /contacts/attributes/{attributeCategory}/{attributeName} | Deletes an attribute
+*ContactsApi* | [**deleteContact**](docs/ContactsApi.md#deleteContact) | **DELETE** /contacts/{email} | Deletes a contact
 *ContactsApi* | [**deleteFolder**](docs/ContactsApi.md#deleteFolder) | **DELETE** /contacts/folders/{folderId} | Delete a folder (and all its lists)
 *ContactsApi* | [**deleteList**](docs/ContactsApi.md#deleteList) | **DELETE** /contacts/lists/{listId} | Delete a list
 *ContactsApi* | [**getAttributes**](docs/ContactsApi.md#getAttributes) | **GET** /contacts/attributes | Lists all attributes

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'idea'
 apply plugin: 'eclipse'
 
 group = 'com.sendinblue'
-version = '2.0.0'
+version = '2.0.1'
 
 buildscript {
     repositories {

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val root = (project in file(".")).
   settings(
     organization := "com.sendinblue",
     name := "sib-api-v3-sdk",
-    version := "2.0.0",
+    version := "2.0.1",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
     javacOptions in compile ++= Seq("-Xlint:deprecation"),

--- a/docs/ContactsApi.md
+++ b/docs/ContactsApi.md
@@ -10,6 +10,7 @@ Method | HTTP request | Description
 [**createFolder**](ContactsApi.md#createFolder) | **POST** /contacts/folders | Create a folder
 [**createList**](ContactsApi.md#createList) | **POST** /contacts/lists | Create a list
 [**deleteAttribute**](ContactsApi.md#deleteAttribute) | **DELETE** /contacts/attributes/{attributeCategory}/{attributeName} | Deletes an attribute
+[**deleteContact**](ContactsApi.md#deleteContact) | **DELETE** /contacts/{email} | Deletes a contact
 [**deleteFolder**](ContactsApi.md#deleteFolder) | **DELETE** /contacts/folders/{folderId} | Delete a folder (and all its lists)
 [**deleteList**](ContactsApi.md#deleteList) | **DELETE** /contacts/lists/{listId} | Delete a list
 [**getAttributes**](ContactsApi.md#getAttributes) | **GET** /contacts/attributes | Lists all attributes
@@ -341,6 +342,58 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **attributeCategory** | **String**| Category of the attribute | [enum: normal, transactional, category, calculated, global]
  **attributeName** | **String**| Name of the existing attribute |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+[api-key](../README.md#api-key)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
+
+<a name="deleteContact"></a>
+# **deleteContact**
+> deleteContact(email)
+
+Deletes a contact
+
+### Example
+```java
+// Import classes:
+//import sendinblue.ApiClient;
+//import sendinblue.ApiException;
+//import sendinblue.Configuration;
+//import sendinblue.auth.*;
+//import sibApi.ContactsApi;
+
+ApiClient defaultClient = Configuration.getDefaultApiClient();
+
+// Configure API key authorization: api-key
+ApiKeyAuth apiKey = (ApiKeyAuth) defaultClient.getAuthentication("api-key");
+apiKey.setApiKey("YOUR API KEY");
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//apiKey.setApiKeyPrefix("Token");
+
+ContactsApi apiInstance = new ContactsApi();
+String email = "email_example"; // String | Email (urlencoded) of the contact
+try {
+    apiInstance.deleteContact(email);
+} catch (ApiException e) {
+    System.err.println("Exception when calling ContactsApi#deleteContact");
+    e.printStackTrace();
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **email** | **String**| Email (urlencoded) of the contact |
 
 ### Return type
 

--- a/docs/GetAccountPlan.md
+++ b/docs/GetAccountPlan.md
@@ -5,10 +5,11 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **type** | [**TypeEnum**](#TypeEnum) | Displays the plan type of the user | 
-**creditsType** | [**CreditsTypeEnum**](#CreditsTypeEnum) | This is the type of the credit, \&quot;User Limit\&quot; or \&quot;Send Limit\&quot; are two possible types of credit of a user. \&quot;User Limit\&quot; implies the total number of subscribers you can add to your account, and \&quot;Send Limit\&quot; implies the total number of emails you can send to the subscribers in your account. | 
-**credits** | **Float** | Remaining credits of the user. This can either be \&quot;User Limit\&quot; or \&quot;Send Limit\&quot; depending on the plan. | 
+**creditsType** | [**CreditsTypeEnum**](#CreditsTypeEnum) | This is the type of the credit, \&quot;Send Limit\&quot; is one of the possible types of credit of a user. \&quot;Send Limit\&quot; implies the total number of emails you can send to the subscribers in your account. | 
+**credits** | **Float** | Remaining credits of the user | 
 **startDate** | **LocalDate** | Date of the period from which the plan will start (only available for \&quot;subscription\&quot;, \&quot;unlimited\&quot; and \&quot;reseller\&quot; plan type) |  [optional]
 **endDate** | **LocalDate** | Date of the period from which the plan will end (only available for \&quot;subscription\&quot;, \&quot;unlimited\&quot; and \&quot;reseller\&quot; plan type) |  [optional]
+**userLimit** | **Integer** | Only in case of reseller account. It implies the total number of child accounts you can add to your account. |  [optional]
 
 
 <a name="TypeEnum"></a>
@@ -27,7 +28,6 @@ RESELLER | &quot;reseller&quot;
 ## Enum: CreditsTypeEnum
 Name | Value
 ---- | -----
-USERLIMIT | &quot;userLimit&quot;
 SENDLIMIT | &quot;sendLimit&quot;
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>sib-api-v3-sdk</artifactId>
     <packaging>jar</packaging>
     <name>sib-api-v3-sdk</name>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <url>https://github.com/sendinblue/APIv3-java-library</url>
     <description>SendinBlue&#39;s API v3 Java Library</description>
     <scm>

--- a/src/main/java/sendinblue/ApiClient.java
+++ b/src/main/java/sendinblue/ApiClient.java
@@ -85,7 +85,7 @@ public class ApiClient {
         json = new Json();
 
         // Set default User-Agent.
-        setUserAgent("Swagger-Codegen/2.0.0/java");
+        setUserAgent("Swagger-Codegen/2.0.1/java");
 
         // Setup authentications (key: authentication name, value: authentication).
         authentications = new HashMap<String, Authentication>();

--- a/src/main/java/sendinblue/ApiException.java
+++ b/src/main/java/sendinblue/ApiException.java
@@ -16,7 +16,7 @@ package sendinblue;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class ApiException extends Exception {
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;

--- a/src/main/java/sendinblue/Configuration.java
+++ b/src/main/java/sendinblue/Configuration.java
@@ -13,7 +13,7 @@
 
 package sendinblue;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class Configuration {
     private static ApiClient defaultApiClient = new ApiClient();
 

--- a/src/main/java/sendinblue/Pair.java
+++ b/src/main/java/sendinblue/Pair.java
@@ -13,7 +13,7 @@
 
 package sendinblue;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class Pair {
     private String name = "";
     private String value = "";

--- a/src/main/java/sendinblue/StringUtil.java
+++ b/src/main/java/sendinblue/StringUtil.java
@@ -13,7 +13,7 @@
 
 package sendinblue;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class StringUtil {
   /**
    * Check if the given array contains the given value (with case-insensitive comparison).

--- a/src/main/java/sendinblue/auth/ApiKeyAuth.java
+++ b/src/main/java/sendinblue/auth/ApiKeyAuth.java
@@ -18,7 +18,7 @@ import sendinblue.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class ApiKeyAuth implements Authentication {
   private final String location;
   private final String paramName;

--- a/src/main/java/sendinblue/auth/OAuth.java
+++ b/src/main/java/sendinblue/auth/OAuth.java
@@ -18,7 +18,7 @@ import sendinblue.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class OAuth implements Authentication {
   private String accessToken;
 

--- a/src/main/java/sibApi/ContactsApi.java
+++ b/src/main/java/sibApi/ContactsApi.java
@@ -844,6 +844,125 @@ public class ContactsApi {
         return call;
     }
     /**
+     * Build call for deleteContact
+     * @param email Email (urlencoded) of the contact (required)
+     * @param progressListener Progress listener
+     * @param progressRequestListener Progress request listener
+     * @return Call to execute
+     * @throws ApiException If fail to serialize the request body object
+     */
+    public com.squareup.okhttp.Call deleteContactCall(String email, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+        Object localVarPostBody = null;
+
+        // create path and map variables
+        String localVarPath = "/contacts/{email}"
+            .replaceAll("\\{" + "email" + "\\}", apiClient.escapeString(email.toString()));
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        final String[] localVarAccepts = {
+            "application/json"
+        };
+        final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) localVarHeaderParams.put("Accept", localVarAccept);
+
+        final String[] localVarContentTypes = {
+            "application/json"
+        };
+        final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+        localVarHeaderParams.put("Content-Type", localVarContentType);
+
+        if(progressListener != null) {
+            apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
+                @Override
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
+                    com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
+                    return originalResponse.newBuilder()
+                    .body(new ProgressResponseBody(originalResponse.body(), progressListener))
+                    .build();
+                }
+            });
+        }
+
+        String[] localVarAuthNames = new String[] { "api-key" };
+        return apiClient.buildCall(localVarPath, "DELETE", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private com.squareup.okhttp.Call deleteContactValidateBeforeCall(String email, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+        
+        // verify the required parameter 'email' is set
+        if (email == null) {
+            throw new ApiException("Missing the required parameter 'email' when calling deleteContact(Async)");
+        }
+        
+
+        com.squareup.okhttp.Call call = deleteContactCall(email, progressListener, progressRequestListener);
+        return call;
+
+    }
+
+    /**
+     * Deletes a contact
+     * 
+     * @param email Email (urlencoded) of the contact (required)
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     */
+    public void deleteContact(String email) throws ApiException {
+        deleteContactWithHttpInfo(email);
+    }
+
+    /**
+     * Deletes a contact
+     * 
+     * @param email Email (urlencoded) of the contact (required)
+     * @return ApiResponse&lt;Void&gt;
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     */
+    public ApiResponse<Void> deleteContactWithHttpInfo(String email) throws ApiException {
+        com.squareup.okhttp.Call call = deleteContactValidateBeforeCall(email, null, null);
+        return apiClient.execute(call);
+    }
+
+    /**
+     * Deletes a contact (asynchronously)
+     * 
+     * @param email Email (urlencoded) of the contact (required)
+     * @param callback The callback to be executed when the API call finishes
+     * @return The request call
+     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     */
+    public com.squareup.okhttp.Call deleteContactAsync(String email, final ApiCallback<Void> callback) throws ApiException {
+
+        ProgressResponseBody.ProgressListener progressListener = null;
+        ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
+
+        if (callback != null) {
+            progressListener = new ProgressResponseBody.ProgressListener() {
+                @Override
+                public void update(long bytesRead, long contentLength, boolean done) {
+                    callback.onDownloadProgress(bytesRead, contentLength, done);
+                }
+            };
+
+            progressRequestListener = new ProgressRequestBody.ProgressRequestListener() {
+                @Override
+                public void onRequestProgress(long bytesWritten, long contentLength, boolean done) {
+                    callback.onUploadProgress(bytesWritten, contentLength, done);
+                }
+            };
+        }
+
+        com.squareup.okhttp.Call call = deleteContactValidateBeforeCall(email, progressListener, progressRequestListener);
+        apiClient.executeAsync(call, callback);
+        return call;
+    }
+    /**
      * Build call for deleteFolder
      * @param folderId Id of the folder (required)
      * @param progressListener Progress listener

--- a/src/main/java/sibModel/AddContactToList.java
+++ b/src/main/java/sibModel/AddContactToList.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * AddContactToList
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class AddContactToList {
   @SerializedName("emails")
   private List<String> emails = null;

--- a/src/main/java/sibModel/AddCredits.java
+++ b/src/main/java/sibModel/AddCredits.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * AddCredits
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class AddCredits {
   @SerializedName("sms")
   private Long sms = null;

--- a/src/main/java/sibModel/CreateAttribute.java
+++ b/src/main/java/sibModel/CreateAttribute.java
@@ -29,7 +29,7 @@ import sibModel.CreateAttributeEnumeration;
 /**
  * CreateAttribute
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class CreateAttribute {
   @SerializedName("value")
   private String value = null;

--- a/src/main/java/sibModel/CreateAttributeEnumeration.java
+++ b/src/main/java/sibModel/CreateAttributeEnumeration.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * CreateAttributeEnumeration
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class CreateAttributeEnumeration {
   @SerializedName("value")
   private Integer value = null;

--- a/src/main/java/sibModel/CreateChild.java
+++ b/src/main/java/sibModel/CreateChild.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * CreateChild
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class CreateChild {
   @SerializedName("email")
   private String email = null;

--- a/src/main/java/sibModel/CreateContact.java
+++ b/src/main/java/sibModel/CreateContact.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * CreateContact
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class CreateContact {
   @SerializedName("email")
   private String email = null;

--- a/src/main/java/sibModel/CreateEmailCampaign.java
+++ b/src/main/java/sibModel/CreateEmailCampaign.java
@@ -29,7 +29,7 @@ import sibModel.CreateEmailCampaignSender;
 /**
  * CreateEmailCampaign
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class CreateEmailCampaign {
   @SerializedName("tag")
   private String tag = null;

--- a/src/main/java/sibModel/CreateEmailCampaignRecipients.java
+++ b/src/main/java/sibModel/CreateEmailCampaignRecipients.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * CreateEmailCampaignRecipients
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class CreateEmailCampaignRecipients {
   @SerializedName("exclusionListIds")
   private List<Long> exclusionListIds = null;

--- a/src/main/java/sibModel/CreateEmailCampaignSender.java
+++ b/src/main/java/sibModel/CreateEmailCampaignSender.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * CreateEmailCampaignSender
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class CreateEmailCampaignSender {
   @SerializedName("name")
   private String name = null;

--- a/src/main/java/sibModel/CreateList.java
+++ b/src/main/java/sibModel/CreateList.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * CreateList
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class CreateList {
   @SerializedName("name")
   private String name = null;

--- a/src/main/java/sibModel/CreateModel.java
+++ b/src/main/java/sibModel/CreateModel.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * CreateModel
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class CreateModel {
   @SerializedName("id")
   private Long id = null;

--- a/src/main/java/sibModel/CreateReseller.java
+++ b/src/main/java/sibModel/CreateReseller.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * CreateReseller
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class CreateReseller {
   @SerializedName("authKey")
   private String authKey = null;

--- a/src/main/java/sibModel/CreateSender.java
+++ b/src/main/java/sibModel/CreateSender.java
@@ -29,7 +29,7 @@ import sibModel.CreateSenderIps;
 /**
  * CreateSender
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class CreateSender {
   @SerializedName("name")
   private String name = null;

--- a/src/main/java/sibModel/CreateSenderIps.java
+++ b/src/main/java/sibModel/CreateSenderIps.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * CreateSenderIps
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class CreateSenderIps {
   @SerializedName("ip")
   private String ip = null;

--- a/src/main/java/sibModel/CreateSenderModel.java
+++ b/src/main/java/sibModel/CreateSenderModel.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * CreateSenderModel
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class CreateSenderModel {
   @SerializedName("id")
   private Long id = null;

--- a/src/main/java/sibModel/CreateSmsCampaign.java
+++ b/src/main/java/sibModel/CreateSmsCampaign.java
@@ -28,7 +28,7 @@ import sibModel.CreateSmsCampaignRecipients;
 /**
  * CreateSmsCampaign
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class CreateSmsCampaign {
   @SerializedName("name")
   private String name = null;

--- a/src/main/java/sibModel/CreateSmsCampaignRecipients.java
+++ b/src/main/java/sibModel/CreateSmsCampaignRecipients.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * CreateSmsCampaignRecipients
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class CreateSmsCampaignRecipients {
   @SerializedName("listIds")
   private List<Long> listIds = new ArrayList<Long>();

--- a/src/main/java/sibModel/CreateSmtpEmail.java
+++ b/src/main/java/sibModel/CreateSmtpEmail.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * CreateSmtpEmail
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class CreateSmtpEmail {
   @SerializedName("messageId")
   private String messageId = null;

--- a/src/main/java/sibModel/CreateSmtpTemplate.java
+++ b/src/main/java/sibModel/CreateSmtpTemplate.java
@@ -27,7 +27,7 @@ import sibModel.CreateSmtpTemplateSender;
 /**
  * CreateSmtpTemplate
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class CreateSmtpTemplate {
   @SerializedName("tag")
   private String tag = null;

--- a/src/main/java/sibModel/CreateSmtpTemplateSender.java
+++ b/src/main/java/sibModel/CreateSmtpTemplateSender.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * CreateSmtpTemplateSender
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class CreateSmtpTemplateSender {
   @SerializedName("name")
   private String name = null;

--- a/src/main/java/sibModel/CreateUpdateFolder.java
+++ b/src/main/java/sibModel/CreateUpdateFolder.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * CreateUpdateFolder
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class CreateUpdateFolder {
   @SerializedName("name")
   private String name = null;

--- a/src/main/java/sibModel/CreateWebhook.java
+++ b/src/main/java/sibModel/CreateWebhook.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * CreateWebhook
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class CreateWebhook {
   @SerializedName("url")
   private String url = null;

--- a/src/main/java/sibModel/CreatedProcessId.java
+++ b/src/main/java/sibModel/CreatedProcessId.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * CreatedProcessId
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class CreatedProcessId {
   @SerializedName("processId")
   private Long processId = null;

--- a/src/main/java/sibModel/DeleteHardbounces.java
+++ b/src/main/java/sibModel/DeleteHardbounces.java
@@ -27,7 +27,7 @@ import org.threeten.bp.LocalDate;
 /**
  * DeleteHardbounces
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class DeleteHardbounces {
   @SerializedName("startDate")
   private LocalDate startDate = null;

--- a/src/main/java/sibModel/EmailExportRecipients.java
+++ b/src/main/java/sibModel/EmailExportRecipients.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * EmailExportRecipients
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class EmailExportRecipients {
   @SerializedName("notifyURL")
   private String notifyURL = null;

--- a/src/main/java/sibModel/ErrorModel.java
+++ b/src/main/java/sibModel/ErrorModel.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * ErrorModel
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class ErrorModel {
   /**
    * Error code displayed in case of a failure

--- a/src/main/java/sibModel/GetAccount.java
+++ b/src/main/java/sibModel/GetAccount.java
@@ -33,7 +33,7 @@ import sibModel.GetExtendedClientAddress;
 /**
  * GetAccount
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetAccount {
   @SerializedName("email")
   private String email = null;

--- a/src/main/java/sibModel/GetAccountMarketingAutomation.java
+++ b/src/main/java/sibModel/GetAccountMarketingAutomation.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * GetAccountMarketingAutomation
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetAccountMarketingAutomation {
   @SerializedName("key")
   private String key = null;

--- a/src/main/java/sibModel/GetAccountPlan.java
+++ b/src/main/java/sibModel/GetAccountPlan.java
@@ -27,7 +27,7 @@ import org.threeten.bp.LocalDate;
 /**
  * GetAccountPlan
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetAccountPlan {
   /**
    * Displays the plan type of the user
@@ -88,12 +88,10 @@ public class GetAccountPlan {
   private TypeEnum type = null;
 
   /**
-   * This is the type of the credit, \&quot;User Limit\&quot; or \&quot;Send Limit\&quot; are two possible types of credit of a user. \&quot;User Limit\&quot; implies the total number of subscribers you can add to your account, and \&quot;Send Limit\&quot; implies the total number of emails you can send to the subscribers in your account.
+   * This is the type of the credit, \&quot;Send Limit\&quot; is one of the possible types of credit of a user. \&quot;Send Limit\&quot; implies the total number of emails you can send to the subscribers in your account.
    */
   @JsonAdapter(CreditsTypeEnum.Adapter.class)
   public enum CreditsTypeEnum {
-    USERLIMIT("userLimit"),
-    
     SENDLIMIT("sendLimit");
 
     private String value;
@@ -146,6 +144,9 @@ public class GetAccountPlan {
   @SerializedName("endDate")
   private LocalDate endDate = null;
 
+  @SerializedName("userLimit")
+  private Integer userLimit = null;
+
   public GetAccountPlan type(TypeEnum type) {
     this.type = type;
     return this;
@@ -170,10 +171,10 @@ public class GetAccountPlan {
   }
 
    /**
-   * This is the type of the credit, \&quot;User Limit\&quot; or \&quot;Send Limit\&quot; are two possible types of credit of a user. \&quot;User Limit\&quot; implies the total number of subscribers you can add to your account, and \&quot;Send Limit\&quot; implies the total number of emails you can send to the subscribers in your account.
+   * This is the type of the credit, \&quot;Send Limit\&quot; is one of the possible types of credit of a user. \&quot;Send Limit\&quot; implies the total number of emails you can send to the subscribers in your account.
    * @return creditsType
   **/
-  @ApiModelProperty(example = "sendLimit", required = true, value = "This is the type of the credit, \"User Limit\" or \"Send Limit\" are two possible types of credit of a user. \"User Limit\" implies the total number of subscribers you can add to your account, and \"Send Limit\" implies the total number of emails you can send to the subscribers in your account.")
+  @ApiModelProperty(example = "sendLimit", required = true, value = "This is the type of the credit, \"Send Limit\" is one of the possible types of credit of a user. \"Send Limit\" implies the total number of emails you can send to the subscribers in your account.")
   public CreditsTypeEnum getCreditsType() {
     return creditsType;
   }
@@ -188,10 +189,10 @@ public class GetAccountPlan {
   }
 
    /**
-   * Remaining credits of the user. This can either be \&quot;User Limit\&quot; or \&quot;Send Limit\&quot; depending on the plan.
+   * Remaining credits of the user
    * @return credits
   **/
-  @ApiModelProperty(example = "8755.0", required = true, value = "Remaining credits of the user. This can either be \"User Limit\" or \"Send Limit\" depending on the plan.")
+  @ApiModelProperty(example = "8755.0", required = true, value = "Remaining credits of the user")
   public Float getCredits() {
     return credits;
   }
@@ -236,6 +237,24 @@ public class GetAccountPlan {
     this.endDate = endDate;
   }
 
+  public GetAccountPlan userLimit(Integer userLimit) {
+    this.userLimit = userLimit;
+    return this;
+  }
+
+   /**
+   * Only in case of reseller account. It implies the total number of child accounts you can add to your account.
+   * @return userLimit
+  **/
+  @ApiModelProperty(example = "10", value = "Only in case of reseller account. It implies the total number of child accounts you can add to your account.")
+  public Integer getUserLimit() {
+    return userLimit;
+  }
+
+  public void setUserLimit(Integer userLimit) {
+    this.userLimit = userLimit;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -250,12 +269,13 @@ public class GetAccountPlan {
     ObjectUtils.equals(this.creditsType, getAccountPlan.creditsType) &&
     ObjectUtils.equals(this.credits, getAccountPlan.credits) &&
     ObjectUtils.equals(this.startDate, getAccountPlan.startDate) &&
-    ObjectUtils.equals(this.endDate, getAccountPlan.endDate);
+    ObjectUtils.equals(this.endDate, getAccountPlan.endDate) &&
+    ObjectUtils.equals(this.userLimit, getAccountPlan.userLimit);
   }
 
   @Override
   public int hashCode() {
-    return ObjectUtils.hashCodeMulti(type, creditsType, credits, startDate, endDate);
+    return ObjectUtils.hashCodeMulti(type, creditsType, credits, startDate, endDate, userLimit);
   }
 
 
@@ -269,6 +289,7 @@ public class GetAccountPlan {
     sb.append("    credits: ").append(toIndentedString(credits)).append("\n");
     sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
     sb.append("    endDate: ").append(toIndentedString(endDate)).append("\n");
+    sb.append("    userLimit: ").append(toIndentedString(userLimit)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/src/main/java/sibModel/GetAccountRelay.java
+++ b/src/main/java/sibModel/GetAccountRelay.java
@@ -28,7 +28,7 @@ import sibModel.GetAccountRelayData;
  * Information about your SMTP account
  */
 @ApiModel(description = "Information about your SMTP account")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetAccountRelay {
   @SerializedName("enabled")
   private Boolean enabled = null;

--- a/src/main/java/sibModel/GetAccountRelayData.java
+++ b/src/main/java/sibModel/GetAccountRelayData.java
@@ -27,7 +27,7 @@ import java.io.IOException;
  * Data regarding the SMTP account
  */
 @ApiModel(description = "Data regarding the SMTP account")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetAccountRelayData {
   @SerializedName("userName")
   private String userName = null;

--- a/src/main/java/sibModel/GetAggregatedReport.java
+++ b/src/main/java/sibModel/GetAggregatedReport.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * GetAggregatedReport
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetAggregatedReport {
   @SerializedName("range")
   private String range = null;

--- a/src/main/java/sibModel/GetAttributes.java
+++ b/src/main/java/sibModel/GetAttributes.java
@@ -29,7 +29,7 @@ import sibModel.GetAttributesAttributes;
 /**
  * GetAttributes
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetAttributes {
   @SerializedName("attributes")
   private List<GetAttributesAttributes> attributes = new ArrayList<GetAttributesAttributes>();

--- a/src/main/java/sibModel/GetAttributesAttributes.java
+++ b/src/main/java/sibModel/GetAttributesAttributes.java
@@ -29,7 +29,7 @@ import sibModel.GetAttributesEnumeration;
 /**
  * GetAttributesAttributes
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetAttributesAttributes {
   @SerializedName("name")
   private String name = null;

--- a/src/main/java/sibModel/GetAttributesEnumeration.java
+++ b/src/main/java/sibModel/GetAttributesEnumeration.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * GetAttributesEnumeration
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetAttributesEnumeration {
   @SerializedName("value")
   private Long value = null;

--- a/src/main/java/sibModel/GetCampaignOverview.java
+++ b/src/main/java/sibModel/GetCampaignOverview.java
@@ -27,7 +27,7 @@ import org.threeten.bp.OffsetDateTime;
 /**
  * GetCampaignOverview
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetCampaignOverview {
   @SerializedName("id")
   private Long id = null;

--- a/src/main/java/sibModel/GetCampaignRecipients.java
+++ b/src/main/java/sibModel/GetCampaignRecipients.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * GetCampaignRecipients
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetCampaignRecipients {
   @SerializedName("lists")
   private List<Long> lists = new ArrayList<Long>();

--- a/src/main/java/sibModel/GetCampaignStats.java
+++ b/src/main/java/sibModel/GetCampaignStats.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * GetCampaignStats
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetCampaignStats {
   @SerializedName("listId")
   private Long listId = null;

--- a/src/main/java/sibModel/GetChildInfo.java
+++ b/src/main/java/sibModel/GetChildInfo.java
@@ -32,7 +32,7 @@ import sibModel.GetClient;
 /**
  * GetChildInfo
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetChildInfo {
   @SerializedName("email")
   private String email = null;

--- a/src/main/java/sibModel/GetChildInfoApiKeys.java
+++ b/src/main/java/sibModel/GetChildInfoApiKeys.java
@@ -31,7 +31,7 @@ import sibModel.GetChildInfoApiKeysV3;
  * API Keys associated to child account
  */
 @ApiModel(description = "API Keys associated to child account")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetChildInfoApiKeys {
   @SerializedName("v2")
   private List<GetChildInfoApiKeysV2> v2 = new ArrayList<GetChildInfoApiKeysV2>();

--- a/src/main/java/sibModel/GetChildInfoApiKeysV2.java
+++ b/src/main/java/sibModel/GetChildInfoApiKeysV2.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * GetChildInfoApiKeysV2
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetChildInfoApiKeysV2 {
   @SerializedName("name")
   private String name = null;

--- a/src/main/java/sibModel/GetChildInfoApiKeysV3.java
+++ b/src/main/java/sibModel/GetChildInfoApiKeysV3.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * GetChildInfoApiKeysV3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetChildInfoApiKeysV3 {
   @SerializedName("name")
   private String name = null;

--- a/src/main/java/sibModel/GetChildInfoCredits.java
+++ b/src/main/java/sibModel/GetChildInfoCredits.java
@@ -27,7 +27,7 @@ import java.io.IOException;
  * Credits available for your child
  */
 @ApiModel(description = "Credits available for your child")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetChildInfoCredits {
   @SerializedName("emailCredits")
   private Long emailCredits = null;

--- a/src/main/java/sibModel/GetChildInfoStatistics.java
+++ b/src/main/java/sibModel/GetChildInfoStatistics.java
@@ -27,7 +27,7 @@ import java.io.IOException;
  * Statistics about your child account activity
  */
 @ApiModel(description = "Statistics about your child account activity")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetChildInfoStatistics {
   @SerializedName("previousMonthTotalSent")
   private Long previousMonthTotalSent = null;

--- a/src/main/java/sibModel/GetChildrenList.java
+++ b/src/main/java/sibModel/GetChildrenList.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * GetChildrenList
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetChildrenList {
   @SerializedName("children")
   private List<Object> children = null;

--- a/src/main/java/sibModel/GetClient.java
+++ b/src/main/java/sibModel/GetClient.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * GetClient
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetClient {
   @SerializedName("email")
   private String email = null;

--- a/src/main/java/sibModel/GetContactCampaignStats.java
+++ b/src/main/java/sibModel/GetContactCampaignStats.java
@@ -34,7 +34,7 @@ import sibModel.GetExtendedContactDetailsStatisticsMessagesSent;
  * Campaign Statistics for the contact
  */
 @ApiModel(description = "Campaign Statistics for the contact")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetContactCampaignStats {
   @SerializedName("messagesSent")
   private List<GetExtendedContactDetailsStatisticsMessagesSent> messagesSent = null;

--- a/src/main/java/sibModel/GetContactCampaignStatsClicked.java
+++ b/src/main/java/sibModel/GetContactCampaignStatsClicked.java
@@ -29,7 +29,7 @@ import sibModel.GetExtendedContactDetailsStatisticsLinks;
 /**
  * GetContactCampaignStatsClicked
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetContactCampaignStatsClicked {
   @SerializedName("campaignId")
   private Long campaignId = null;

--- a/src/main/java/sibModel/GetContactCampaignStatsOpened.java
+++ b/src/main/java/sibModel/GetContactCampaignStatsOpened.java
@@ -27,7 +27,7 @@ import org.threeten.bp.OffsetDateTime;
 /**
  * GetContactCampaignStatsOpened
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetContactCampaignStatsOpened {
   @SerializedName("campaignId")
   private Long campaignId = null;

--- a/src/main/java/sibModel/GetContactCampaignStatsTransacAttributes.java
+++ b/src/main/java/sibModel/GetContactCampaignStatsTransacAttributes.java
@@ -27,7 +27,7 @@ import org.threeten.bp.LocalDate;
 /**
  * GetContactCampaignStatsTransacAttributes
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetContactCampaignStatsTransacAttributes {
   @SerializedName("orderDate")
   private LocalDate orderDate = null;

--- a/src/main/java/sibModel/GetContactCampaignStatsUnsubscriptions.java
+++ b/src/main/java/sibModel/GetContactCampaignStatsUnsubscriptions.java
@@ -30,7 +30,7 @@ import sibModel.GetExtendedContactDetailsStatisticsUnsubscriptionsUserUnsubscrip
 /**
  * GetContactCampaignStatsUnsubscriptions
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetContactCampaignStatsUnsubscriptions {
   @SerializedName("userUnsubscription")
   private List<GetExtendedContactDetailsStatisticsUnsubscriptionsUserUnsubscription> userUnsubscription = new ArrayList<GetExtendedContactDetailsStatisticsUnsubscriptionsUserUnsubscription>();

--- a/src/main/java/sibModel/GetContactDetails.java
+++ b/src/main/java/sibModel/GetContactDetails.java
@@ -31,7 +31,7 @@ import org.threeten.bp.OffsetDateTime;
 /**
  * GetContactDetails
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetContactDetails {
   @SerializedName("email")
   private String email = null;

--- a/src/main/java/sibModel/GetContacts.java
+++ b/src/main/java/sibModel/GetContacts.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * GetContacts
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetContacts {
   @SerializedName("contacts")
   private List<Object> contacts = new ArrayList<Object>();

--- a/src/main/java/sibModel/GetEmailCampaign.java
+++ b/src/main/java/sibModel/GetEmailCampaign.java
@@ -29,7 +29,7 @@ import sibModel.GetExtendedCampaignOverviewSender;
 /**
  * GetEmailCampaign
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetEmailCampaign {
   @SerializedName("id")
   private Long id = null;

--- a/src/main/java/sibModel/GetEmailCampaigns.java
+++ b/src/main/java/sibModel/GetEmailCampaigns.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * GetEmailCampaigns
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetEmailCampaigns {
   @SerializedName("campaigns")
   private List<Object> campaigns = null;

--- a/src/main/java/sibModel/GetEmailEventReport.java
+++ b/src/main/java/sibModel/GetEmailEventReport.java
@@ -29,7 +29,7 @@ import sibModel.GetEmailEventReportEvents;
 /**
  * GetEmailEventReport
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetEmailEventReport {
   @SerializedName("events")
   private List<GetEmailEventReportEvents> events = null;

--- a/src/main/java/sibModel/GetEmailEventReportEvents.java
+++ b/src/main/java/sibModel/GetEmailEventReportEvents.java
@@ -27,7 +27,7 @@ import org.threeten.bp.OffsetDateTime;
 /**
  * GetEmailEventReportEvents
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetEmailEventReportEvents {
   @SerializedName("email")
   private String email = null;

--- a/src/main/java/sibModel/GetExtendedCampaignOverview.java
+++ b/src/main/java/sibModel/GetExtendedCampaignOverview.java
@@ -29,7 +29,7 @@ import sibModel.GetExtendedCampaignOverviewSender;
 /**
  * GetExtendedCampaignOverview
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetExtendedCampaignOverview {
   @SerializedName("id")
   private Long id = null;

--- a/src/main/java/sibModel/GetExtendedCampaignOverviewSender.java
+++ b/src/main/java/sibModel/GetExtendedCampaignOverviewSender.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * GetExtendedCampaignOverviewSender
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetExtendedCampaignOverviewSender {
   @SerializedName("name")
   private String name = null;

--- a/src/main/java/sibModel/GetExtendedCampaignStats.java
+++ b/src/main/java/sibModel/GetExtendedCampaignStats.java
@@ -32,7 +32,7 @@ import sibModel.GetStatsByDomain;
 /**
  * GetExtendedCampaignStats
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetExtendedCampaignStats {
   @SerializedName("campaignStats")
   private List<Object> campaignStats = new ArrayList<Object>();

--- a/src/main/java/sibModel/GetExtendedCampaignStatsLinksStats.java
+++ b/src/main/java/sibModel/GetExtendedCampaignStatsLinksStats.java
@@ -27,7 +27,7 @@ import java.io.IOException;
  * Statistics about the clicked links
  */
 @ApiModel(description = "Statistics about the clicked links")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetExtendedCampaignStatsLinksStats {
   @SerializedName("nbClick")
   private Long nbClick = null;

--- a/src/main/java/sibModel/GetExtendedClient.java
+++ b/src/main/java/sibModel/GetExtendedClient.java
@@ -28,7 +28,7 @@ import sibModel.GetExtendedClientAddress;
 /**
  * GetExtendedClient
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetExtendedClient {
   @SerializedName("email")
   private String email = null;

--- a/src/main/java/sibModel/GetExtendedClientAddress.java
+++ b/src/main/java/sibModel/GetExtendedClientAddress.java
@@ -27,7 +27,7 @@ import java.io.IOException;
  * Address informations
  */
 @ApiModel(description = "Address informations")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetExtendedClientAddress {
   @SerializedName("street")
   private String street = null;

--- a/src/main/java/sibModel/GetExtendedContactDetails.java
+++ b/src/main/java/sibModel/GetExtendedContactDetails.java
@@ -33,7 +33,7 @@ import sibModel.GetExtendedContactDetailsStatistics;
 /**
  * GetExtendedContactDetails
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetExtendedContactDetails {
   @SerializedName("email")
   private String email = null;

--- a/src/main/java/sibModel/GetExtendedContactDetailsStatistics.java
+++ b/src/main/java/sibModel/GetExtendedContactDetailsStatistics.java
@@ -33,7 +33,7 @@ import sibModel.GetExtendedContactDetailsStatisticsUnsubscriptions;
  * Campaign statistics of the contact
  */
 @ApiModel(description = "Campaign statistics of the contact")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetExtendedContactDetailsStatistics {
   @SerializedName("messagesSent")
   private List<GetExtendedContactDetailsStatisticsMessagesSent> messagesSent = null;

--- a/src/main/java/sibModel/GetExtendedContactDetailsStatisticsClicked.java
+++ b/src/main/java/sibModel/GetExtendedContactDetailsStatisticsClicked.java
@@ -29,7 +29,7 @@ import sibModel.GetExtendedContactDetailsStatisticsLinks;
 /**
  * GetExtendedContactDetailsStatisticsClicked
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetExtendedContactDetailsStatisticsClicked {
   @SerializedName("campaignId")
   private Long campaignId = null;

--- a/src/main/java/sibModel/GetExtendedContactDetailsStatisticsLinks.java
+++ b/src/main/java/sibModel/GetExtendedContactDetailsStatisticsLinks.java
@@ -27,7 +27,7 @@ import org.threeten.bp.OffsetDateTime;
 /**
  * GetExtendedContactDetailsStatisticsLinks
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetExtendedContactDetailsStatisticsLinks {
   @SerializedName("count")
   private Long count = null;

--- a/src/main/java/sibModel/GetExtendedContactDetailsStatisticsMessagesSent.java
+++ b/src/main/java/sibModel/GetExtendedContactDetailsStatisticsMessagesSent.java
@@ -27,7 +27,7 @@ import org.threeten.bp.OffsetDateTime;
 /**
  * GetExtendedContactDetailsStatisticsMessagesSent
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetExtendedContactDetailsStatisticsMessagesSent {
   @SerializedName("campaignId")
   private Long campaignId = null;

--- a/src/main/java/sibModel/GetExtendedContactDetailsStatisticsOpened.java
+++ b/src/main/java/sibModel/GetExtendedContactDetailsStatisticsOpened.java
@@ -27,7 +27,7 @@ import org.threeten.bp.OffsetDateTime;
 /**
  * GetExtendedContactDetailsStatisticsOpened
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetExtendedContactDetailsStatisticsOpened {
   @SerializedName("campaignId")
   private Long campaignId = null;

--- a/src/main/java/sibModel/GetExtendedContactDetailsStatisticsUnsubscriptions.java
+++ b/src/main/java/sibModel/GetExtendedContactDetailsStatisticsUnsubscriptions.java
@@ -31,7 +31,7 @@ import sibModel.GetExtendedContactDetailsStatisticsUnsubscriptionsUserUnsubscrip
  * Listing of the unsubscription for the contact
  */
 @ApiModel(description = "Listing of the unsubscription for the contact")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetExtendedContactDetailsStatisticsUnsubscriptions {
   @SerializedName("userUnsubscription")
   private List<GetExtendedContactDetailsStatisticsUnsubscriptionsUserUnsubscription> userUnsubscription = new ArrayList<GetExtendedContactDetailsStatisticsUnsubscriptionsUserUnsubscription>();

--- a/src/main/java/sibModel/GetExtendedContactDetailsStatisticsUnsubscriptionsAdminUnsubscription.java
+++ b/src/main/java/sibModel/GetExtendedContactDetailsStatisticsUnsubscriptionsAdminUnsubscription.java
@@ -27,7 +27,7 @@ import org.threeten.bp.OffsetDateTime;
 /**
  * GetExtendedContactDetailsStatisticsUnsubscriptionsAdminUnsubscription
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetExtendedContactDetailsStatisticsUnsubscriptionsAdminUnsubscription {
   @SerializedName("eventTime")
   private OffsetDateTime eventTime = null;

--- a/src/main/java/sibModel/GetExtendedContactDetailsStatisticsUnsubscriptionsUserUnsubscription.java
+++ b/src/main/java/sibModel/GetExtendedContactDetailsStatisticsUnsubscriptionsUserUnsubscription.java
@@ -27,7 +27,7 @@ import org.threeten.bp.OffsetDateTime;
 /**
  * GetExtendedContactDetailsStatisticsUnsubscriptionsUserUnsubscription
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetExtendedContactDetailsStatisticsUnsubscriptionsUserUnsubscription {
   @SerializedName("campaignId")
   private Long campaignId = null;

--- a/src/main/java/sibModel/GetExtendedList.java
+++ b/src/main/java/sibModel/GetExtendedList.java
@@ -31,7 +31,7 @@ import sibModel.GetList;
 /**
  * GetExtendedList
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetExtendedList {
   @SerializedName("id")
   private Long id = null;

--- a/src/main/java/sibModel/GetExtendedListCampaignStats.java
+++ b/src/main/java/sibModel/GetExtendedListCampaignStats.java
@@ -27,7 +27,7 @@ import sibModel.GetCampaignStats;
 /**
  * GetExtendedListCampaignStats
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetExtendedListCampaignStats {
   @SerializedName("campaignId")
   private Long campaignId = null;

--- a/src/main/java/sibModel/GetFolder.java
+++ b/src/main/java/sibModel/GetFolder.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * GetFolder
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetFolder {
   @SerializedName("id")
   private Long id = null;

--- a/src/main/java/sibModel/GetFolderLists.java
+++ b/src/main/java/sibModel/GetFolderLists.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * GetFolderLists
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetFolderLists {
   @SerializedName("lists")
   private List<Object> lists = new ArrayList<Object>();

--- a/src/main/java/sibModel/GetFolders.java
+++ b/src/main/java/sibModel/GetFolders.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * GetFolders
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetFolders {
   @SerializedName("folders")
   private List<Object> folders = null;

--- a/src/main/java/sibModel/GetIp.java
+++ b/src/main/java/sibModel/GetIp.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * GetIp
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetIp {
   @SerializedName("id")
   private Long id = null;

--- a/src/main/java/sibModel/GetIpFromSender.java
+++ b/src/main/java/sibModel/GetIpFromSender.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * GetIpFromSender
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetIpFromSender {
   @SerializedName("id")
   private Long id = null;

--- a/src/main/java/sibModel/GetIps.java
+++ b/src/main/java/sibModel/GetIps.java
@@ -29,7 +29,7 @@ import sibModel.GetIp;
 /**
  * GetIps
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetIps {
   @SerializedName("ips")
   private List<GetIp> ips = new ArrayList<GetIp>();

--- a/src/main/java/sibModel/GetIpsFromSender.java
+++ b/src/main/java/sibModel/GetIpsFromSender.java
@@ -29,7 +29,7 @@ import sibModel.GetIpFromSender;
 /**
  * GetIpsFromSender
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetIpsFromSender {
   @SerializedName("ips")
   private List<GetIpFromSender> ips = new ArrayList<GetIpFromSender>();

--- a/src/main/java/sibModel/GetList.java
+++ b/src/main/java/sibModel/GetList.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * GetList
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetList {
   @SerializedName("id")
   private Long id = null;

--- a/src/main/java/sibModel/GetLists.java
+++ b/src/main/java/sibModel/GetLists.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * GetLists
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetLists {
   @SerializedName("lists")
   private List<Object> lists = new ArrayList<Object>();

--- a/src/main/java/sibModel/GetProcess.java
+++ b/src/main/java/sibModel/GetProcess.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * GetProcess
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetProcess {
   @SerializedName("id")
   private Long id = null;

--- a/src/main/java/sibModel/GetProcesses.java
+++ b/src/main/java/sibModel/GetProcesses.java
@@ -29,7 +29,7 @@ import sibModel.GetProcess;
 /**
  * GetProcesses
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetProcesses {
   @SerializedName("processes")
   private List<GetProcess> processes = null;

--- a/src/main/java/sibModel/GetReports.java
+++ b/src/main/java/sibModel/GetReports.java
@@ -29,7 +29,7 @@ import sibModel.GetReportsReports;
 /**
  * GetReports
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetReports {
   @SerializedName("reports")
   private List<GetReportsReports> reports = null;

--- a/src/main/java/sibModel/GetReportsReports.java
+++ b/src/main/java/sibModel/GetReportsReports.java
@@ -27,7 +27,7 @@ import org.threeten.bp.LocalDate;
 /**
  * GetReportsReports
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetReportsReports {
   @SerializedName("date")
   private LocalDate date = null;

--- a/src/main/java/sibModel/GetSendersList.java
+++ b/src/main/java/sibModel/GetSendersList.java
@@ -29,7 +29,7 @@ import sibModel.GetSendersListSenders;
 /**
  * GetSendersList
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetSendersList {
   @SerializedName("senders")
   private List<GetSendersListSenders> senders = null;

--- a/src/main/java/sibModel/GetSendersListIps.java
+++ b/src/main/java/sibModel/GetSendersListIps.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * GetSendersListIps
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetSendersListIps {
   @SerializedName("ip")
   private String ip = null;

--- a/src/main/java/sibModel/GetSendersListSenders.java
+++ b/src/main/java/sibModel/GetSendersListSenders.java
@@ -29,7 +29,7 @@ import sibModel.GetSendersListIps;
 /**
  * GetSendersListSenders
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetSendersListSenders {
   @SerializedName("id")
   private Long id = null;

--- a/src/main/java/sibModel/GetSmsCampaign.java
+++ b/src/main/java/sibModel/GetSmsCampaign.java
@@ -28,7 +28,7 @@ import sibModel.GetSmsCampaignOverview;
 /**
  * GetSmsCampaign
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetSmsCampaign {
   @SerializedName("id")
   private Long id = null;

--- a/src/main/java/sibModel/GetSmsCampaignOverview.java
+++ b/src/main/java/sibModel/GetSmsCampaignOverview.java
@@ -27,7 +27,7 @@ import org.threeten.bp.OffsetDateTime;
 /**
  * GetSmsCampaignOverview
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetSmsCampaignOverview {
   @SerializedName("id")
   private Long id = null;

--- a/src/main/java/sibModel/GetSmsCampaignStats.java
+++ b/src/main/java/sibModel/GetSmsCampaignStats.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * GetSmsCampaignStats
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetSmsCampaignStats {
   @SerializedName("delivered")
   private Long delivered = null;

--- a/src/main/java/sibModel/GetSmsCampaigns.java
+++ b/src/main/java/sibModel/GetSmsCampaigns.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * GetSmsCampaigns
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetSmsCampaigns {
   @SerializedName("campaigns")
   private List<Object> campaigns = null;

--- a/src/main/java/sibModel/GetSmsEventReport.java
+++ b/src/main/java/sibModel/GetSmsEventReport.java
@@ -29,7 +29,7 @@ import sibModel.GetSmsEventReportEvents;
 /**
  * GetSmsEventReport
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetSmsEventReport {
   @SerializedName("events")
   private List<GetSmsEventReportEvents> events = null;

--- a/src/main/java/sibModel/GetSmsEventReportEvents.java
+++ b/src/main/java/sibModel/GetSmsEventReportEvents.java
@@ -27,7 +27,7 @@ import org.threeten.bp.LocalDate;
 /**
  * GetSmsEventReportEvents
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetSmsEventReportEvents {
   @SerializedName("phoneNumber")
   private String phoneNumber = null;

--- a/src/main/java/sibModel/GetSmtpTemplateOverview.java
+++ b/src/main/java/sibModel/GetSmtpTemplateOverview.java
@@ -28,7 +28,7 @@ import sibModel.GetSmtpTemplateOverviewSender;
 /**
  * GetSmtpTemplateOverview
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetSmtpTemplateOverview {
   @SerializedName("id")
   private Long id = null;

--- a/src/main/java/sibModel/GetSmtpTemplateOverviewSender.java
+++ b/src/main/java/sibModel/GetSmtpTemplateOverviewSender.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * GetSmtpTemplateOverviewSender
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetSmtpTemplateOverviewSender {
   @SerializedName("name")
   private String name = null;

--- a/src/main/java/sibModel/GetSmtpTemplates.java
+++ b/src/main/java/sibModel/GetSmtpTemplates.java
@@ -29,7 +29,7 @@ import sibModel.GetSmtpTemplateOverview;
 /**
  * GetSmtpTemplates
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetSmtpTemplates {
   @SerializedName("count")
   private Long count = null;

--- a/src/main/java/sibModel/GetStatsByDomain.java
+++ b/src/main/java/sibModel/GetStatsByDomain.java
@@ -21,7 +21,7 @@ import sibModel.GetCampaignStats;
 /**
  * GetStatsByDomain
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetStatsByDomain extends HashMap<String, GetCampaignStats> {
 
   @Override

--- a/src/main/java/sibModel/GetTransacAggregatedSmsReport.java
+++ b/src/main/java/sibModel/GetTransacAggregatedSmsReport.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * GetTransacAggregatedSmsReport
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetTransacAggregatedSmsReport {
   @SerializedName("range")
   private String range = null;

--- a/src/main/java/sibModel/GetTransacSmsReport.java
+++ b/src/main/java/sibModel/GetTransacSmsReport.java
@@ -29,7 +29,7 @@ import sibModel.GetTransacSmsReportReports;
 /**
  * GetTransacSmsReport
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetTransacSmsReport {
   @SerializedName("reports")
   private List<GetTransacSmsReportReports> reports = null;

--- a/src/main/java/sibModel/GetTransacSmsReportReports.java
+++ b/src/main/java/sibModel/GetTransacSmsReportReports.java
@@ -27,7 +27,7 @@ import org.threeten.bp.LocalDate;
 /**
  * GetTransacSmsReportReports
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetTransacSmsReportReports {
   @SerializedName("date")
   private LocalDate date = null;

--- a/src/main/java/sibModel/GetWebhook.java
+++ b/src/main/java/sibModel/GetWebhook.java
@@ -29,7 +29,7 @@ import org.threeten.bp.OffsetDateTime;
 /**
  * GetWebhook
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetWebhook {
   @SerializedName("url")
   private String url = null;

--- a/src/main/java/sibModel/GetWebhooks.java
+++ b/src/main/java/sibModel/GetWebhooks.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * GetWebhooks
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class GetWebhooks {
   @SerializedName("webhooks")
   private List<Object> webhooks = new ArrayList<Object>();

--- a/src/main/java/sibModel/ManageIp.java
+++ b/src/main/java/sibModel/ManageIp.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * ManageIp
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class ManageIp {
   @SerializedName("ip")
   private String ip = null;

--- a/src/main/java/sibModel/PostContactInfo.java
+++ b/src/main/java/sibModel/PostContactInfo.java
@@ -27,7 +27,7 @@ import sibModel.PostContactInfoContacts;
 /**
  * PostContactInfo
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class PostContactInfo {
   @SerializedName("contacts")
   private PostContactInfoContacts contacts = null;

--- a/src/main/java/sibModel/PostContactInfoContacts.java
+++ b/src/main/java/sibModel/PostContactInfoContacts.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * PostContactInfoContacts
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class PostContactInfoContacts {
   @SerializedName("success")
   private List<String> success = new ArrayList<String>();

--- a/src/main/java/sibModel/PostSendFailed.java
+++ b/src/main/java/sibModel/PostSendFailed.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * PostSendFailed
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class PostSendFailed {
   @SerializedName("code")
   private Long code = null;

--- a/src/main/java/sibModel/PostSendSmsTestFailed.java
+++ b/src/main/java/sibModel/PostSendSmsTestFailed.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * PostSendSmsTestFailed
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class PostSendSmsTestFailed {
   @SerializedName("code")
   private Long code = null;

--- a/src/main/java/sibModel/RemainingCreditModel.java
+++ b/src/main/java/sibModel/RemainingCreditModel.java
@@ -28,7 +28,7 @@ import sibModel.RemainingCreditModelReseller;
 /**
  * RemainingCreditModel
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class RemainingCreditModel {
   @SerializedName("child")
   private RemainingCreditModelChild child = null;

--- a/src/main/java/sibModel/RemainingCreditModelChild.java
+++ b/src/main/java/sibModel/RemainingCreditModelChild.java
@@ -27,7 +27,7 @@ import java.io.IOException;
  * Credits remaining for child account
  */
 @ApiModel(description = "Credits remaining for child account")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class RemainingCreditModelChild {
   @SerializedName("sms")
   private Long sms = null;

--- a/src/main/java/sibModel/RemainingCreditModelReseller.java
+++ b/src/main/java/sibModel/RemainingCreditModelReseller.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * RemainingCreditModelReseller
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class RemainingCreditModelReseller {
   @SerializedName("sms")
   private Long sms = null;

--- a/src/main/java/sibModel/RemoveContactFromList.java
+++ b/src/main/java/sibModel/RemoveContactFromList.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * RemoveContactFromList
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class RemoveContactFromList {
   @SerializedName("emails")
   private List<String> emails = null;

--- a/src/main/java/sibModel/RemoveCredits.java
+++ b/src/main/java/sibModel/RemoveCredits.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * RemoveCredits
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class RemoveCredits {
   @SerializedName("sms")
   private Long sms = null;

--- a/src/main/java/sibModel/RequestContactExport.java
+++ b/src/main/java/sibModel/RequestContactExport.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * RequestContactExport
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class RequestContactExport {
   @SerializedName("exportAttributes")
   private List<String> exportAttributes = null;

--- a/src/main/java/sibModel/RequestContactImport.java
+++ b/src/main/java/sibModel/RequestContactImport.java
@@ -29,7 +29,7 @@ import sibModel.RequestContactImportNewList;
 /**
  * RequestContactImport
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class RequestContactImport {
   @SerializedName("fileUrl")
   private String fileUrl = null;

--- a/src/main/java/sibModel/RequestContactImportNewList.java
+++ b/src/main/java/sibModel/RequestContactImportNewList.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * RequestContactImportNewList
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class RequestContactImportNewList {
   @SerializedName("listName")
   private String listName = null;

--- a/src/main/java/sibModel/RequestSmsRecipientExport.java
+++ b/src/main/java/sibModel/RequestSmsRecipientExport.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * RequestSmsRecipientExport
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class RequestSmsRecipientExport {
   @SerializedName("notifyURL")
   private String notifyURL = null;

--- a/src/main/java/sibModel/SendEmail.java
+++ b/src/main/java/sibModel/SendEmail.java
@@ -31,7 +31,7 @@ import sibModel.SendEmailAttachment;
 /**
  * SendEmail
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class SendEmail {
   @SerializedName("emailTo")
   private List<String> emailTo = new ArrayList<String>();

--- a/src/main/java/sibModel/SendEmailAttachment.java
+++ b/src/main/java/sibModel/SendEmailAttachment.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * SendEmailAttachment
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class SendEmailAttachment {
   @SerializedName("content")
   private byte[] content = null;

--- a/src/main/java/sibModel/SendReport.java
+++ b/src/main/java/sibModel/SendReport.java
@@ -27,7 +27,7 @@ import sibModel.SendReportEmail;
 /**
  * SendReport
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class SendReport {
   /**
    * Language of email content for campaign report sending.

--- a/src/main/java/sibModel/SendReportEmail.java
+++ b/src/main/java/sibModel/SendReportEmail.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * SendReportEmail
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class SendReportEmail {
   @SerializedName("subject")
   private String subject = null;

--- a/src/main/java/sibModel/SendSms.java
+++ b/src/main/java/sibModel/SendSms.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * SendSms
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class SendSms {
   @SerializedName("reference")
   private String reference = null;

--- a/src/main/java/sibModel/SendSmtpEmail.java
+++ b/src/main/java/sibModel/SendSmtpEmail.java
@@ -36,7 +36,7 @@ import sibModel.SendSmtpEmailTo;
 /**
  * SendSmtpEmail
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class SendSmtpEmail {
   @SerializedName("sender")
   private SendSmtpEmailSender sender = null;

--- a/src/main/java/sibModel/SendSmtpEmailAttachment.java
+++ b/src/main/java/sibModel/SendSmtpEmailAttachment.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * SendSmtpEmailAttachment
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class SendSmtpEmailAttachment {
   @SerializedName("url")
   private String url = null;

--- a/src/main/java/sibModel/SendSmtpEmailBcc.java
+++ b/src/main/java/sibModel/SendSmtpEmailBcc.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * SendSmtpEmailBcc
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class SendSmtpEmailBcc {
   @SerializedName("email")
   private String email = null;

--- a/src/main/java/sibModel/SendSmtpEmailCc.java
+++ b/src/main/java/sibModel/SendSmtpEmailCc.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * SendSmtpEmailCc
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class SendSmtpEmailCc {
   @SerializedName("email")
   private String email = null;

--- a/src/main/java/sibModel/SendSmtpEmailReplyTo.java
+++ b/src/main/java/sibModel/SendSmtpEmailReplyTo.java
@@ -27,7 +27,7 @@ import java.io.IOException;
  * Email on which transactional mail recipients will be able to reply to
  */
 @ApiModel(description = "Email on which transactional mail recipients will be able to reply to")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class SendSmtpEmailReplyTo {
   @SerializedName("email")
   private String email = null;

--- a/src/main/java/sibModel/SendSmtpEmailSender.java
+++ b/src/main/java/sibModel/SendSmtpEmailSender.java
@@ -27,7 +27,7 @@ import java.io.IOException;
  * Sender from which emails are sent. Mandatory if &#39;templateId&#39; is not passed
  */
 @ApiModel(description = "Sender from which emails are sent. Mandatory if 'templateId' is not passed")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class SendSmtpEmailSender {
   @SerializedName("name")
   private String name = null;

--- a/src/main/java/sibModel/SendSmtpEmailTo.java
+++ b/src/main/java/sibModel/SendSmtpEmailTo.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * SendSmtpEmailTo
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class SendSmtpEmailTo {
   @SerializedName("email")
   private String email = null;

--- a/src/main/java/sibModel/SendTemplateEmail.java
+++ b/src/main/java/sibModel/SendTemplateEmail.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * SendTemplateEmail
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class SendTemplateEmail {
   @SerializedName("messageId")
   private String messageId = null;

--- a/src/main/java/sibModel/SendTestEmail.java
+++ b/src/main/java/sibModel/SendTestEmail.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * SendTestEmail
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class SendTestEmail {
   @SerializedName("emailTo")
   private List<String> emailTo = null;

--- a/src/main/java/sibModel/SendTestSms.java
+++ b/src/main/java/sibModel/SendTestSms.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * SendTestSms
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class SendTestSms {
   @SerializedName("phoneNumbers")
   private List<String> phoneNumbers = null;

--- a/src/main/java/sibModel/SendTransacSms.java
+++ b/src/main/java/sibModel/SendTransacSms.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * SendTransacSms
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class SendTransacSms {
   @SerializedName("sender")
   private String sender = null;

--- a/src/main/java/sibModel/UpdateAttribute.java
+++ b/src/main/java/sibModel/UpdateAttribute.java
@@ -29,7 +29,7 @@ import sibModel.UpdateAttributeEnumeration;
 /**
  * UpdateAttribute
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class UpdateAttribute {
   @SerializedName("value")
   private String value = null;

--- a/src/main/java/sibModel/UpdateAttributeEnumeration.java
+++ b/src/main/java/sibModel/UpdateAttributeEnumeration.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * UpdateAttributeEnumeration
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class UpdateAttributeEnumeration {
   @SerializedName("value")
   private Integer value = null;

--- a/src/main/java/sibModel/UpdateCampaignStatus.java
+++ b/src/main/java/sibModel/UpdateCampaignStatus.java
@@ -27,7 +27,7 @@ import java.io.IOException;
  * Status of the campaign
  */
 @ApiModel(description = "Status of the campaign")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class UpdateCampaignStatus {
   /**
    * Gets or Sets status

--- a/src/main/java/sibModel/UpdateChild.java
+++ b/src/main/java/sibModel/UpdateChild.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * UpdateChild
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class UpdateChild {
   @SerializedName("email")
   private String email = null;

--- a/src/main/java/sibModel/UpdateContact.java
+++ b/src/main/java/sibModel/UpdateContact.java
@@ -30,7 +30,7 @@ import java.util.Map;
 /**
  * UpdateContact
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class UpdateContact {
   @SerializedName("attributes")
   private Map<String, String> attributes = null;

--- a/src/main/java/sibModel/UpdateEmailCampaign.java
+++ b/src/main/java/sibModel/UpdateEmailCampaign.java
@@ -29,7 +29,7 @@ import sibModel.UpdateEmailCampaignSender;
 /**
  * UpdateEmailCampaign
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class UpdateEmailCampaign {
   @SerializedName("tag")
   private String tag = null;

--- a/src/main/java/sibModel/UpdateEmailCampaignRecipients.java
+++ b/src/main/java/sibModel/UpdateEmailCampaignRecipients.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * UpdateEmailCampaignRecipients
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class UpdateEmailCampaignRecipients {
   @SerializedName("exclusionListIds")
   private List<Long> exclusionListIds = null;

--- a/src/main/java/sibModel/UpdateEmailCampaignSender.java
+++ b/src/main/java/sibModel/UpdateEmailCampaignSender.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * UpdateEmailCampaignSender
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class UpdateEmailCampaignSender {
   @SerializedName("name")
   private String name = null;

--- a/src/main/java/sibModel/UpdateList.java
+++ b/src/main/java/sibModel/UpdateList.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * UpdateList
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class UpdateList {
   @SerializedName("name")
   private String name = null;

--- a/src/main/java/sibModel/UpdateSender.java
+++ b/src/main/java/sibModel/UpdateSender.java
@@ -29,7 +29,7 @@ import sibModel.CreateSenderIps;
 /**
  * UpdateSender
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class UpdateSender {
   @SerializedName("name")
   private String name = null;

--- a/src/main/java/sibModel/UpdateSmsCampaign.java
+++ b/src/main/java/sibModel/UpdateSmsCampaign.java
@@ -28,7 +28,7 @@ import sibModel.CreateSmsCampaignRecipients;
 /**
  * UpdateSmsCampaign
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class UpdateSmsCampaign {
   @SerializedName("name")
   private String name = null;

--- a/src/main/java/sibModel/UpdateSmtpTemplate.java
+++ b/src/main/java/sibModel/UpdateSmtpTemplate.java
@@ -27,7 +27,7 @@ import sibModel.UpdateSmtpTemplateSender;
 /**
  * UpdateSmtpTemplate
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class UpdateSmtpTemplate {
   @SerializedName("tag")
   private String tag = null;

--- a/src/main/java/sibModel/UpdateSmtpTemplateSender.java
+++ b/src/main/java/sibModel/UpdateSmtpTemplateSender.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * UpdateSmtpTemplateSender
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class UpdateSmtpTemplateSender {
   @SerializedName("name")
   private String name = null;

--- a/src/main/java/sibModel/UpdateWebhook.java
+++ b/src/main/java/sibModel/UpdateWebhook.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * UpdateWebhook
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-03-23T10:53:13.078+05:30")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-04-13T14:27:50.128+05:30")
 public class UpdateWebhook {
   @SerializedName("url")
   private String url = null;

--- a/src/test/java/sibApi/ContactsApiTest.java
+++ b/src/test/java/sibApi/ContactsApiTest.java
@@ -157,6 +157,22 @@ public class ContactsApiTest {
     }
     
     /**
+     * Deletes a contact
+     *
+     * 
+     *
+     * @throws ApiException
+     *          if the Api call fails
+     */
+    @Test
+    public void deleteContactTest() throws ApiException {
+        String email = null;
+        api.deleteContact(email);
+
+        // TODO: test validations
+    }
+    
+    /**
      * Delete a folder (and all its lists)
      *
      * 


### PR DESCRIPTION
- Add new method `DELETE /contacts/{email}` to delete single contact
- `getAccount` definition response schema fix for Reseller account